### PR TITLE
report nosetest coverage

### DIFF
--- a/.codecov.sh
+++ b/.codecov.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Export CI environment info
+ci_env=`bash <(curl -s https://codecov.io/env)`
+export DOCKER_RUN_OPTS="$DOCKER_RUN_OPTS $ci_env"

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -12,7 +12,9 @@ for pkg in $COVERAGE_PKGS; do
     ici_exec_in_workspace "$extend" "$ws" catkin build $pkg -v --no-deps --catkin-make-args $pkg_coverage_report
 
     # each package will overwrite the previous, rename the coverage file
-    mv /root/.ros/coverage.xml /root/.ros/coverage_$pkg.xml
+    mv "/root/.ros/coverage.xml" "/root/.ros/coverage_$pkg.xml"
+
+done
 
 echo "Uploading coverage results to codecov.io"
 

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -11,11 +11,9 @@ for pkg in $COVERAGE_PKGS; do
     extend="/opt/ros/$ROS_DISTRO"
     ici_exec_in_workspace "$extend" "$ws" catkin build $pkg -v --no-deps --catkin-make-args $pkg_coverage_report
 
-    # each package will overwrite the previous, rename the coverage file
-    mv "/root/.ros/coverage.xml" "/root/.ros/coverage_$pkg.xml"
+    echo "Uploading coverage results to codecov.io"
+
+    # Codecov will merge all these reports
+    bash <(curl -s https://codecov.io/bash) -s /root/.ros
 
 done
-
-echo "Uploading coverage results to codecov.io"
-
-bash <(curl -s https://codecov.io/bash) -s /root/.ros

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -9,7 +9,7 @@ for pkg in $COVERAGE_PKGS; do
 
     ws=~/target_ws
     extend="/opt/ros/$ROS_DISTRO"
-    ici_exec_in_workspace "$extend" "$ws" catkin build $pkg -v --no-deps --catkin-make-args $pkg_coverage_report
+    ici_exec_in_workspace "$extend" "$ws" catkin build $pkg -v --no-deps --catkin-make-args ${pkg}_coverage_report
 
     echo "Uploading coverage results to codecov.io"
 

--- a/.coverage.sh
+++ b/.coverage.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+source "${ICI_SRC_PATH}/workspace.sh"
+source "${ICI_SRC_PATH}/util.sh"
+
+for pkg in $COVERAGE_PKGS; do
+
+    echo "Generating coverage for $pkg"
+
+    ws=~/target_ws
+    extend="/opt/ros/$ROS_DISTRO"
+    ici_exec_in_workspace "$extend" "$ws" catkin build $pkg -v --no-deps --catkin-make-args $pkg_coverage_report
+
+    # each package will overwrite the previous, rename the coverage file
+    mv /root/.ros/coverage.xml /root/.ros/coverage_$pkg.xml
+
+echo "Uploading coverage results to codecov.io"
+
+bash <(curl -s https://codecov.io/bash) -s /root/.ros

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,14 @@ jobs:
         - ADDITIONAL_DEBS="curl"
         - ROS_DISTRO="melodic"
         - UPSTREAM_WORKSPACE="upstream.repos"
-        - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug"
-        - DOCKER_RUN_OPTS="-e TRAVIS_COMMIT=$TRAVIS_COMMIT -e CODECOV_TOKEN=$CODECOV_TOKEN"
-        # Manually trigger combine (we aren't actually calling code_coverage target)
-        - AFTER_RUN_TARGET_TEST="cd /root/.ros && python-coverage combine && python-coverage xml"
-        # Upload coverage information to codecov.io
-        - AFTER_AFTER_RUN_TARGET_TEST="bash <(curl -s https://codecov.io/bash) -s /root/.ros -C $TRAVIS_COMMIT"
+        # Build with coverage on, debug required for proper information in C++
+        - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug""
+        # List of packages to generate coverage reports for
+        - COVERAGE_PKGS="example_pkg"
+        - DOCKER_RUN_OPTS="- $COVERAGE_PKGS"
+        # Run coverage testing
+        - AFTER_SCRIPT="./.coverage.sh"
       install:
         - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b master
       script:
-        - .industrial_ci/travis.sh
+        - source ./.codecov.sh && .industrial_ci/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         # Build with coverage on, debug required for proper information in C++
         - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug""
         # List of packages to generate coverage reports
-        - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg" -e ROS_HOME="/root/.ros"'
+        - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg"'
         # Run coverage testing
         - AFTER_SCRIPT="./.coverage.sh"
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         # Build with coverage on, debug required for proper information in C++
         - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug""
         # List of packages to generate coverage reports
-        - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg"
+        - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg"'
         # Run coverage testing
         - AFTER_SCRIPT="./.coverage.sh"
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ jobs:
         # Build with coverage on, debug required for proper information in C++
         - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug""
         # List of packages to generate coverage reports
-        - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg"'
+        - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg" -e ROS_HOME="/root/.ros"'
         # Run coverage testing
         - AFTER_SCRIPT="./.coverage.sh"
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jobs:
         - ROS_DISTRO="melodic"
         - UPSTREAM_WORKSPACE="upstream.repos"
         # Build with coverage on, debug required for proper information in C++
-        - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug""
+        - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug"
         # List of packages to generate coverage reports
         - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg"'
         # Run coverage testing

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,8 @@ jobs:
         - UPSTREAM_WORKSPACE="upstream.repos"
         # Build with coverage on, debug required for proper information in C++
         - CMAKE_ARGS="-DENABLE_COVERAGE_TESTING=ON -DCMAKE_BUILD_TYPE=Debug""
-        # List of packages to generate coverage reports for
-        - COVERAGE_PKGS="example_pkg"
-        - DOCKER_RUN_OPTS="- $COVERAGE_PKGS"
+        # List of packages to generate coverage reports
+        - DOCKER_RUN_OPTS='-e COVERAGE_PKGS="example_pkg"
         # Run coverage testing
         - AFTER_SCRIPT="./.coverage.sh"
       install:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
 TravisCI: [![Build Status](https://travis-ci.org/SarvagyaVaish/ros_ci_and_coverage.svg?branch=master)](https://travis-ci.org/SarvagyaVaish/ros_ci_and_coverage)
 
 Codecov: [![codecov](https://codecov.io/gh/SarvagyaVaish/ros_ci_and_coverage/branch/master/graph/badge.svg)](https://codecov.io/gh/SarvagyaVaish/ros_ci_and_coverage)
-

--- a/example_ws/src/example_pkg/CMakeLists.txt
+++ b/example_ws/src/example_pkg/CMakeLists.txt
@@ -1,200 +1,21 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(example_pkg)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   rospy
   std_msgs
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
 catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   std_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
 
 ###################################
 ## catkin specific configuration ##
 ###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES example_pkg
-#  CATKIN_DEPENDS rospy std_msgs
-#  DEPENDS system_lib
-)
 
 if (CATKIN_ENABLE_TESTING AND ENABLE_COVERAGE_TESTING)
   find_package(code_coverage REQUIRED)
   APPEND_COVERAGE_COMPILER_FLAGS()
 endif()
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-include_directories(
-# include
-  ${catkin_INCLUDE_DIRS}
-)
-
-## Declare a C++ library
-# add_library(${PROJECT_NAME}
-#   src/${PROJECT_NAME}/example_pkg.cpp
-# )
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/example_pkg_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(${PROJECT_NAME}_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
-# install(TARGETS ${PROJECT_NAME}_node
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark libraries for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
-# install(TARGETS ${PROJECT_NAME}
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
 
 #############
 ## Testing ##

--- a/example_ws/src/example_pkg/CMakeLists.txt
+++ b/example_ws/src/example_pkg/CMakeLists.txt
@@ -210,7 +210,7 @@ if (CATKIN_ENABLE_TESTING)
   add_rostest(test/sample_rostest.test ARGS coverage:=ENABLE_COVERAGE_TESTING)
 
   if (ENABLE_COVERAGE_TESTING)
-    set(COVERAGE_EXLCUDES "*/${PROJECT_NAME}/test*")
+    set(COVERAGE_EXCLUDES "*/${PROJECT_NAME}/test*")
     add_code_coverage(
       NAME ${PROJECT_NAME}_coverage_report
       DEPENDENCIES tests

--- a/example_ws/src/example_pkg/src/example_pkg/utils.py
+++ b/example_ws/src/example_pkg/src/example_pkg/utils.py
@@ -12,3 +12,10 @@ def foo_bar():
         return True
     else:
         return False
+
+
+def foo_bar_2():
+    if 4 % 2 == 0:
+        return True
+    else:
+        return False

--- a/example_ws/src/example_pkg/src/example_pkg/utils.py
+++ b/example_ws/src/example_pkg/src/example_pkg/utils.py
@@ -19,3 +19,10 @@ def foo_bar_2():
         return True
     else:
         return False
+
+
+def foo_bar_3():
+    if 4 % 2 == 0:
+        return True
+    else:
+        return False

--- a/example_ws/src/example_pkg/test/sample_rostest.py
+++ b/example_ws/src/example_pkg/test/sample_rostest.py
@@ -10,6 +10,9 @@ class SampelRostest(unittest.TestCase):
     def test_smoke(self):
         self.assertTrue(True)
 
+    def test_smoke_2(self):
+        self.assertTrue(False)
+
 
 if __name__ == "__main__":
     rospy.init_node("sim_test_cases")

--- a/example_ws/src/example_pkg/test/sample_rostest.py
+++ b/example_ws/src/example_pkg/test/sample_rostest.py
@@ -10,9 +10,6 @@ class SampelRostest(unittest.TestCase):
     def test_smoke(self):
         self.assertTrue(True)
 
-    def test_smoke_2(self):
-        self.assertTrue(False)
-
 
 if __name__ == "__main__":
     rospy.init_node("sim_test_cases")

--- a/example_ws/src/example_pkg/test/test_utils.py
+++ b/example_ws/src/example_pkg/test/test_utils.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from example_pkg.utils import get_time_str
+from example_pkg.utils import get_time_str, foo_bar_2
 
 
 class TestUtils(unittest.TestCase):
@@ -11,4 +11,11 @@ class TestUtils(unittest.TestCase):
         Smoke test for get_time_str
         """
         get_time_str()
+        self.assertTrue(True)
+
+    def test_foo_bar_2(self):
+        """
+        Smoke test for foo_bar_2
+        """
+        foo_bar_2()
         self.assertTrue(True)


### PR DESCRIPTION
This, combined with upstream fixes in code_coverage, make sure that nosetest coverage actually gets run.

Also added:
 * CI_ENV through a script like in robot_calibration
 * Moved the logic for processing coverage into an AFTER_SCRIPT. This takes COVERAGE_PKGS, which can later be expanded to a list of pkgs to run coverage on.